### PR TITLE
Reduced Matrix Elements

### DIFF
--- a/ExternalField/EJOperator.cpp
+++ b/ExternalField/EJOperator.cpp
@@ -169,7 +169,7 @@ void EMCalculator::PrintHeader() const
     // Print the appropriate header for the type of transitions we're printing:
     // either reduced matrix elements of transition line strengths (the
     // default)
-    if(user_input.search("--ReducedMatrixElems")){
+    if(user_input.search("--reduced-elements")){
       *outstream << Name(type) << J << " reduced matrix elements (T):" 
           << std::endl;
     } else {
@@ -188,7 +188,7 @@ void EMCalculator::PrintTransition(const LevelID& left, const LevelID& right, do
 
     // Read over the user input to see if we need to print the reduced matrix
     // elements or the transition line strengths
-    if(user_input.search("--ReducedMatrixElems")){ 
+    if(user_input.search("--reduced-elements")){ 
       *outstream << "  " << Name(left) << " -> " << Name(right)
                << " = " << std::setprecision(6) << value << std::endl;
     } else {


### PR DESCRIPTION
Added command line option to print the reduced transition matrix elements instead of the default transition line strengths. Whether or not to print the reduced matrix elements can be declared separately for each transition type by passing in the --ReducedMatrixElems flag in that transition types section. For example:

[Transitions]
E1/--ReducedMatrixElems
E1/AllBelow = -2.0
E2/--ReducedMatrixElems
E2/AllBelow = -2.0
M1/AllBelow = -2.0

will print the reduced matrix elements for E1 and E2 transitions, but will print the transition line strengths for M1 transitions.

This feature is necessary to use results from AMBiT's CI routines in atomic polarisability and photon-atom scattering calculations. These methods require the sign information contained in the ``plain'' reduced transition matrix elements which are lost when calculating the transition line strengths.
